### PR TITLE
Messages with links in it must be parsed

### DIFF
--- a/resources/mw.UploadWizardDetails.js
+++ b/resources/mw.UploadWizardDetails.js
@@ -1339,7 +1339,7 @@ mw.UploadWizardDetails.prototype = {
 				} else if ( warnings['bad-prefix'] ) {
 					_this.recoverFromError( _this.titleId, mw.msg( 'mwe-upwiz-error-title-senselessimagename' ) );
 				} else if ( warnings.exists || warnings['exists-normalized'] ) {
-					_this.recoverFromError( _this.titleId, mw.msg( 'mwe-upwiz-api-warning-exists', _this.upload.title.getUrl() ) );
+					_this.recoverFromError( _this.titleId, mw.message( 'mwe-upwiz-api-warning-exists', _this.upload.title.getUrl() ).parse() );
 				} else if ( warnings.duplicate ) {
 					_this.recoverFromError( _this.titleId, mw.msg( 'mwe-upwiz-upload-error-duplicate' ) );
 				} else if ( warnings['duplicate-archive'] ) {


### PR DESCRIPTION
Otherwise something like
"There is [/wiki/File:Amphoe_Sukhothai.svg another file] already on the wiki with the same filename" 
is returned and shown as such to the user.

C.f. http://www.mediawiki.org/wiki/RL/DM#mediaWiki.message

Bug: 47935
