### PR TITLE
Add only Files from filelist for processing

### DIFF
--- a/resources/mw.UploadWizardUploadInterface.js
+++ b/resources/mw.UploadWizardUploadInterface.js
@@ -291,12 +291,15 @@ mw.UploadWizardUploadInterface.prototype = {
 	 */
 	getFiles: function() {
 		var files = [];
+
 		if ( mw.fileApi.isAvailable() ) {
 			if( this.providedFile && !this.$fileInputCtrl.first().value ) {  // default to the fileinput if it's defined.
 				files[0] = this.providedFile;
 			} else {
 				$.each( this.$fileInputCtrl.get(0).files, function( i, file ) {
-					files.push( file );
+					if ( window.File && Object.prototype.toString.call( file ) === '[object File]' ) {
+						files.push( file );
+					}
 				} );
 			}
 		}


### PR DESCRIPTION
According to bug 46845, Firefox returns filelists containing undefined among File objects after selecting multiple files in certain situations. This can be easily caught and catching these rare occurrences does not cause any harm. String comparison is being used to retain compatibility when involving multiple different DOMs (just in case) instead of the must simpler instanceof File.

I found one other implementation that also checks for the type before processing it:
https://github.com/Widen/fine-uploader/blob/d16737baa3dede3221996fd40b7ddbaac081817a/client/js/uploader.basic.api.js#L109

Nonetheless, clients should only return filelists that consist entirely of file objects:
http://dev.w3.org/2006/webapi/FileAPI/#filelist-section

Bug: 46845
